### PR TITLE
Added `@Include` UDA and support for `interface`s

### DIFF
--- a/src/xserial/attribute.d
+++ b/src/xserial/attribute.d
@@ -13,6 +13,14 @@ import xserial.serial : EndianType;
 enum Exclude;
 
 /**
+ * Includes this even if it would otherwise be excluded.
+ * If Exclude (or other UDA(@)) and Include are present value will be included.
+ * Can also be used on @property methods to include them. (Be sure both the setter and getter exist!)
+ * If used on a value of a base class value will be included.
+ */
+ enum Include;
+
+/**
  * Excludes the field from decoding, encode only.
  */
 enum EncodeOnly;
@@ -58,7 +66,7 @@ template Length(T) if(isVar!T) { enum Length = LengthImpl(T.Base.stringof, Endia
 
 LengthImpl EndianLength(T)(Endian endianness) if(isIntegral!T) { return LengthImpl(T.stringof, endianness); }
 
-struct Custom(T) if(is(T == struct) || is(T == class)) { alias C = T; }
+struct Custom(T) if(is(T == struct) || is(T == class) || is(T == interface)) { alias C = T; }
 
 unittest { // for code coverage
 

--- a/src/xserial/package.d
+++ b/src/xserial/package.d
@@ -2,5 +2,5 @@ module xserial;
 
 public import xbuffer;
 
-public import xserial.attribute : Exclude, EncodeOnly, DecodeOnly, Condition, BigEndian, LittleEndian, Var, NoLength, Length, Custom;
+public import xserial.attribute : Exclude, Include, EncodeOnly, DecodeOnly, Condition, BigEndian, LittleEndian, Var, NoLength, Length, Custom;
 public import xserial.serial : serialize, deserialize;

--- a/src/xserial/serial.d
+++ b/src/xserial/serial.d
@@ -128,7 +128,7 @@ template Members(T, alias Only) {
 					(
 						hasUDA!(__traits(getMember, T, member), Include) ||
 						(
-							__traits(derivedMembers, T).canFind(member) &&
+							[__traits(derivedMembers, T)].canFind(member) &&
 							!__traits(compiles, { mixin("auto test=T." ~ member ~ ";"); }) &&			// static members
 							!__traits(compiles, { mixin("auto test=T.init." ~ member ~ "();"); }) &&	// properties
 							!hasUDA!(__traits(getMember, T, member), Exclude) &&

--- a/src/xserial/serial.d
+++ b/src/xserial/serial.d
@@ -1,8 +1,9 @@
-﻿module xserial.serial;
+module xserial.serial;
 
 import std.system : Endian, endian;
 import std.traits : isArray, isDynamicArray, isStaticArray, isAssociativeArray, ForeachType, KeyType, ValueType, isIntegral, isFloatingPoint, isSomeChar, isType, isCallable, isPointer, hasUDA, getUDAs;
 import std.typecons : isTuple;
+import std.algorithm.searching : canFind;
 
 import xbuffer.buffer : canSwapEndianness, Buffer, BufferOverflowException;
 import xbuffer.memory : xalloc, xfree;
@@ -118,17 +119,23 @@ template Members(T, alias Only) {
 	mixin({
 			
 		string ret = "alias Members = TypeTuple!(";
-		foreach(member ; __traits(derivedMembers, T)) {
+		foreach(member ; __traits(allMembers, T)) {
 			static if(is(typeof(mixin("T." ~ member)))) {
 				mixin("alias M = typeof(T." ~ member ~ ");");
 				static if(
 					isType!M &&
 					!isCallable!M &&
-					!__traits(compiles, { mixin("auto test=T." ~ member ~ ";"); }) &&			// static members
-					!__traits(compiles, { mixin("auto test=T.init." ~ member ~ "();"); }) &&	// properties
-					!hasUDA!(__traits(getMember, T, member), Exclude) &&
-					!hasUDA!(__traits(getMember, T, member), Only)
-					) {
+					(
+						hasUDA!(__traits(getMember, T, member), Include) ||
+						(
+							__traits(derivedMembers, T).canFind(member) &&
+							!__traits(compiles, { mixin("auto test=T." ~ member ~ ";"); }) &&			// static members
+							!__traits(compiles, { mixin("auto test=T.init." ~ member ~ "();"); }) &&	// properties
+							!hasUDA!(__traits(getMember, T, member), Exclude) &&
+							!hasUDA!(__traits(getMember, T, member), Only)
+						)
+					)
+					){
 					ret ~= `"` ~ member ~ `",`;
 					
 				}
@@ -158,7 +165,7 @@ void serializeImpl(EndianType endianness, OL, EndianType ole, CL, EndianType cle
 		serializeAssociativeArray!(endianness, OL, ole)(buffer, value);
 	} else static if(isTuple!T) {
 		serializeTuple!(endianness, OL, ole)(buffer, value);
-	} else static if(is(T == class) || is(T == struct)) {
+	} else static if(is(T == class) || is(T == struct) || is(T == interface)) {
 		static if(__traits(hasMember, T, "serialize") && __traits(compiles, value.serialize(buffer))) {
 			value.serialize(buffer);
 		} else {
@@ -237,7 +244,7 @@ void serializeMembers(EndianType endianness, L, EndianType le, T)(Buffer __buffe
 			else static if(hasUDA!(__traits(getMember, T, member), BigEndian)) immutable ret = "xserial.serial.serializeImpl!(EndianType.bigEndian, " ~ e ~ ", M)(__buffer, __container." ~ member ~ ");";
 			else static if(hasUDA!(__traits(getMember, T, member), LittleEndian)) immutable ret = "xserial.serial.serializeImpl!(EndianType.littleEndian, " ~ e ~ ", M)(__buffer, __container." ~ member ~ ");";
 			else immutable ret = "xserial.serial.serializeImpl!(endianness, " ~ e ~ ", M)(__buffer, __container." ~ member ~ ");";
-
+			
 			static if(!hasUDA!(__traits(getMember, T, member), Condition)) return ret;
 			else return "with(__container){if(" ~ getUDAs!(__traits(getMember, T, member), Condition)[0].condition ~ "){" ~ ret ~ "}}";
 			


### PR DESCRIPTION
Can be used to override an `@exclude`:
class A {
    @Exclude:
    int notIncluded;
    @Include int included;
}

Can also be used for `@property` methods:
class A {
    @Include @property {
        int included() {return 0}
        void included(int value) {}
    }
}

Can also be use on members of base classes.
class Base {
    @include int included;
}
class A : Base {
    // Included even though value is in base class
}