### PR TITLE
Added the ability for custom `Include` and `Exclude` UDAs.  If multiple UDAs are given the last applies (with exception).

### DIFF
--- a/src/xserial/attribute.d
+++ b/src/xserial/attribute.d
@@ -1,4 +1,4 @@
-﻿module xserial.attribute;
+module xserial.attribute;
 
 import std.system : Endian;
 import std.traits : isIntegral;
@@ -14,19 +14,35 @@ enum Exclude;
 
 /**
  * Includes this even if it would otherwise be excluded.
- * If Exclude (or other UDA(@)) and Include are present value will be included.
+ * If Exclude (or other UDA(@)) and Include are present the last one is used, except when excluded with `@EncodeOnly` or `@DecodeOnly`.
  * Can also be used on @property methods to include them. (Be sure both the setter and getter exist!)
  * If used on a value of a base class value will be included.
  */
- enum Include;
+enum Include;
+
+/**
+ * Used for advanced addedUDAs
+ */
+template Excluder(UDA_) {
+	alias UDA = UDA_;
+}
+
+/**
+ * Used for advanced addedUDAs
+ */
+template Includer(UDA_) {
+	alias UDA = UDA_;
+}
 
 /**
  * Excludes the field from decoding, encode only.
+ * Field with be excluded in decoding regardles of any other UDA.
  */
 enum EncodeOnly;
 
 /**
  * Excludes the field from encoding, decode only.
+ * Field with be excluded in encoding regardles of any other UDA.
  */
 enum DecodeOnly;
 
@@ -73,3 +89,5 @@ unittest { // for code coverage
 	EndianLength!uint(Endian.bigEndian);
 
 }
+
+

--- a/src/xserial/attribute.d
+++ b/src/xserial/attribute.d
@@ -23,14 +23,14 @@ enum Include;
 /**
  * Used for advanced addedUDAs
  */
-template Excluder(UDA_) {
+template Excluder(alias UDA_) {
 	alias UDA = UDA_;
 }
 
 /**
  * Used for advanced addedUDAs
  */
-template Includer(UDA_) {
+template Includer(alias UDA_) {
 	alias UDA = UDA_;
 }
 

--- a/src/xserial/serial.d
+++ b/src/xserial/serial.d
@@ -677,3 +677,22 @@ void deserializeMembers(EndianType endianness, L, EndianType le, C, AddedUDAs...
 	assert(buffer.data.length == 0);
 
 }
+
+@("because the coverage report does not understand CTFE") unittest{
+	enum G;
+	enum N;
+	struct Test1 {
+		ubyte z;
+		@Exclude:
+		@G ubyte a;
+		
+		@Include @N ubyte b;
+		
+		@Condition("a==1") ubyte c;
+		@G {
+			ubyte d;
+			@N ubyte e;
+		}
+	}
+	auto test1 = getSerializeMembers!(Test1, EncodeOnly, Includer!G, Excluder!N);
+}


### PR DESCRIPTION
I added some feature I need of a project of mine.  I hope you will accept them up stream.

You can now give custom Include or Exclude UDAs:
```
Grouped!(Includer!CustomInclude, Excluder!CustomInclude, Includer!Another).serialize(data);
```
```
enum A;
enum B;
class Data {
	@A int a;
	@Exclude @B int b;
}
serialize(data); // `a` included;
Grouped!(Excluder!A).serialize(data); // returns [];
Grouped!(Includer!B).serialize(data); // `a` and `b` included.
```

The last of stacked UDAs is used (with exception to @DecodeOnly and @EncodeOnly):
```
class Data {
	int a; // included
@Exclude:
	int b; // excluded
	@Include int c; // included.
@Condition(cond):
	int d; // if condition
	@Include int e; // included
	@Exclude int f; // excluded
	@Condition(cond) int g; // if second condition (first is ignored)
@DecodeOnly:
	// Nothing will ever be encoded (only decoded).  `@DecodeOnly` and `@EncodeOnly` override.
	@Exclude int h; // alway excluded
	@Exclude @Include; // only decoded
}
````